### PR TITLE
Update 3.1_Introduction_to_Widget_Tests.md

### DIFF
--- a/3_Widget_Tests/3.1_Introduction_to_Widget_Tests.md
+++ b/3_Widget_Tests/3.1_Introduction_to_Widget_Tests.md
@@ -26,7 +26,7 @@ Widget tests use the testWidgets function. Here's an example of testing a simple
 void main() {
   testWidgets('Renders a raised button', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(RaisedButton(onPressed: () {}, child: Text('Click me')));
+    await tester.pumpWidget(MaterialApp(home:RaisedButton(onPressed: () {}, child: Text('Click me'))));
 
     // Verify if the button is displayed.
     expect(find.byType(RaisedButton), findsOneWidget);


### PR DESCRIPTION
added MaterialApp to avoid Directionality widget error

Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the
top of your application widget tree. It determines the ambient reading direction and is used, for
example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve
EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.
